### PR TITLE
[PRODSEC-3273]: Change secrets scanning channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ workflows:
           trusted-branch: main
           context:
             - snyk-bot-slack
-          channel: sec-eng-deployments
+          channel: snyk-vuln-alerts-security-intelligence
           filters:
             branches:
               ignore:


### PR DESCRIPTION
[PRODSEC-3273]: Change secrets scanning channel from sec-eng-deployments to snyk-vuln-alerts-security-intelligence

-- 
Committed by prodsec-tools-v2 using octopilot