### PR TITLE
chore: remove ci context snyk-security-rnd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,23 +145,18 @@ workflows:
       - lint:
           name: Run Linters
           executor_name: linters
-          context: snyk-security-rnd
       - test:
           name: Run Tests - python 3.11
           executor_name: python311
-          context: snyk-security-rnd
       - test:
           name: Run Tests - python 3.10
           executor_name: python310
-          context: snyk-security-rnd
       - test:
           name: Run Tests - python 3.9
           executor_name: python39
-          context: snyk-security-rnd
       - test:
           name: Run Tests - python 3.8
           executor_name: python38
-          context: snyk-security-rnd
   release:
     jobs:
       - build_and_release:


### PR DESCRIPTION
CircleCI context snyk-security-rnd is now deleted.
This pr removes the context from [faker-security](https://github.com/snyk/faker-security)

https://snyksec.atlassian.net/browse/RKT-3400