### PR TITLE
[PRODSEC-5058]: Change repo ownership from security-intelligence to intelligence-engineering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ workflows:
           trusted-branch: main
           context:
             - snyk-bot-slack
-          channel: sec-eng-deployments
+          channel: snyk-vuln-alerts-intelligence-engineering
           filters:
             branches:
               ignore:
@@ -141,7 +141,7 @@ workflows:
       - security-scans:
           name: Security Scans
           context:
-            - analysis_security_intelligence
+            - codesec_intelligence-engineering
       - lint:
           name: Run Linters
           executor_name: linters

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/security-intelligence
+* @snyk/intelligence-engineering

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   type: external-library
   lifecycle: "-"
-  owner: security-intelligence
+  owner: intelligence-engineering


### PR DESCRIPTION
[PRODSEC-5058]: Change repo ownership from security-intelligence to intelligence-engineering in `.github/CODEOWNERS`, `.circleci/config.yml` (snyk circleci context, secrets alerts channel) and `catalog-info.yaml` (github.com/team-slug, owner)

-- 
Committed by prodsec-tools-v2 using octopilot

[PRODSEC-5058]: https://snyksec.atlassian.net/browse/PRODSEC-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ