### PR TITLE
chore: update codeowners and catalog-info owner [PRODSEC-10671]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/intelligence-engineering @snyk/open-source_intelligence-engineering
+* @snyk/engines_intelligence-engineering @snyk/open-source_intelligence-engineering @snyk/intelligence-engineering

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   type: external-library
   lifecycle: "-"
-  owner: intelligence-engineering
+  owner: engines_intelligence-engineering


### PR DESCRIPTION
Sets the CODEOWNERS default `*` rule to the github governance managed teams:

```
* @snyk/engines_intelligence-engineering @snyk/open-source_intelligence-engineering @snyk/intelligence-engineering
```

Also moves `spec.owner` in `catalog-info.yaml` from `intelligence-engineering` to `engines_intelligence-engineering`.

CODEOWNERS path-specific rules and comments are left untouched, as are catalog entities owned by any other team. Repository collaborator permissions are not changed by this PR.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change